### PR TITLE
Update getopt.R

### DIFF
--- a/R/getopt.R
+++ b/R/getopt.R
@@ -381,10 +381,11 @@ getopt = function (spec=NULL,opt=commandArgs(TRUE),command=get_Rscript_filename(
 
     #invalid opt
     if ( current.flag == 0 ) {
-      stop(paste('"', optstring, '" is not a valid option, or does not support an argument', sep=''));
+      #stop(paste('"', optstring, '" is not a valid option, or does not support an argument', sep=''));
       #TBD support for positional args
-      #if ( debug ) print(paste('"', optstring, '" not a valid option.  It is appended to getopt(...)$ARGS', sep=''));
-      #result$ARGS = append(result$ARGS, optstring);
+      if ( debug ) print(paste('"', optstring, '" not a valid option.  It is appended to getopt(...)$ARGS', sep=''));
+      a <- optstring; while(substr(a, start = nchar(a), stop = nchar(a))==' ') a <- substr(a, 1, stop = nchar(a) - 1);
+      result$ARGS = append(result$ARGS,a);
 
     # some dangling flag, handle it
     } else if ( current.flag > 0 ) {


### PR DESCRIPTION
Push unused args onto ARGS, similar to getopt(1) and getopt(3), instead of returning an error.

Unlimited right license to change, which is after all contained in your code as a comment.

Example:
source("R/utils.R")
source("R/getopt.R");spec=matrix(c('verbose', 'v', 2, "integer",
                                                       'help'   , 'h', 0, "logical",
                                                       'count'  , 'c', 1, "integer",
                                                       'mean'   , 'm', 1, "double",
                                                       'sd'     , 's', 1, "double"), byrow=TRUE, ncol=4)
args<-c("-v","--sd=17","myfoo","mybar","--mean",18)
opt=getopt(spec,opt=args)
cat("#Unused args=",length(opt$ARGS),"\n")
cat ("args:",paste0(opt$ARGS,collapse=', '),"\n")
opt$ARGS=NULL
for(i in names(opt))cat(i,"=",unlist(opt)[i],"\n", sep = "")
